### PR TITLE
tweak oxmysql example connection string

### DIFF
--- a/docs/oxmysql/Getting Started/index.md
+++ b/docs/oxmysql/Getting Started/index.md
@@ -16,8 +16,8 @@ You can change the configuration settings by using convars inside your `server.c
 Reference the following for an idea of how to set your connection options.
 You must include one of the following lines, adjusted for your connection and database settings.
 ```
-set mysql_connection_string "mysql://root:12345@localhost/es_extended?charset=utf8mb4"
-set mysql_connection_string "user=root;database=es_extended;password=12345;charset=utf8mb4"
+set mysql_connection_string "mysql://root:12345@localhost:3306/es_extended?charset=utf8mb4"
+set mysql_connection_string "user=root;password=12345;host=localhost;port=3306;database=es_extended;charset=utf8mb4"
 ```
 Certain special characters are reserved or blocked and may cause issues when used in your password.  
 For more optional settings (such as multiple statements) you can reference [pool.d.ts](https://github.com/sidorares/node-mysql2/blob/master/typings/mysql/lib/Pool.d.ts#L10) and [connection.d.ts](https://github.com/sidorares/node-mysql2/blob/master/typings/mysql/lib/Connection.d.ts#L8).  


### PR DESCRIPTION
- Adds port to both example strings
- Adds host to custom connection string variant for parity reasons.
- Re-ordered entries in connection strings to mirror each other.