### PR TITLE
docs(ox_inventory/esx): setup typo

### DIFF
--- a/docs/ox_inventory/Getting Started/esx.md
+++ b/docs/ox_inventory/Getting Started/esx.md
@@ -34,7 +34,7 @@ start ox_inventory
 
 - Execute the query inside [install.sql](https://github.com/overextended/ox_inventory/blob/main/setup/install.sql) to create the ox_inventory database table.
 - Open `fxmanifest.lua` and uncomment `server_script 'setup/convert.lua'`.
-- Start the server and type `convertinventory` into the server console.
+- Start the server and type `convertinventory esx` into the server console.
 - Disable `setup/convert.lua` and restart the server.
 
 </TabItem>


### PR DESCRIPTION
Another small typo in the usage
refer to https://github.com/overextended/ox_inventory/blob/main/setup/convert.lua#L283-L296