### PR TITLE
ox_lib: add canClose option to menu

### DIFF
--- a/docs/ox_lib/Interface/Client/menu.md
+++ b/docs/ox_lib/Interface/Client/menu.md
@@ -20,6 +20,7 @@ Registers and caches a menu under the specified id.
     -- args: any (optional)
   -- position: 'top-left' or 'top-right' or 'bottom-left' or 'bottom-right' (optional - default is top-left)
   -- disableInput: boolean (optional - default false)
+  -- canClose: boolean (optional - default true)
   -- onClose: function (optional)
   -- onSelected: function (optional - triggers every time a new button is selected)
   -- onSideScroll: function (optional - triggers every time a side list is scrolled)


### PR DESCRIPTION
This PR adds the "canClose" option to the menu documentation.

This should be merged when the next version of ox_lib comes out.