### PR TITLE
fix(link): redirecting server doc

### DIFF
--- a/docs/ox_core/Player/Server/methods.md
+++ b/docs/ox_core/Player/Server/methods.md
@@ -5,7 +5,7 @@ title: Methods
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-These functions are inherited from the [Player class](../Server/).
+These functions are inherited from the [Player class](..).
 
 ## player.set
 


### PR DESCRIPTION
Fix from https://overextended.github.io/docs/ox_core/Player/Server/Server/ to https://overextended.github.io/docs/ox_core/Player/Server/