### PR TITLE
Added docs for Ox.GetVehicleFromNetId() and other small changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+yarn.lock

--- a/docs/ox_core/Vehicle/Server/index.md
+++ b/docs/ox_core/Vehicle/Server/index.md
@@ -12,6 +12,15 @@ local vehicle = Ox.GetVehicle(entity)
 print(json.encode(vehicle, { indent = true }))
 ```
 
+## Ox.GetVehicleFromNetId
+
+Return an instance of CVehicle for the given entity, this time using it's netId.
+
+```lua
+local vehicle = Ox.GetVehicleFromNetId(netId)
+print(json.encode(vehicle, { indent = true }))
+```
+
 ## Ox.GetVehicles
 
 Returns an array containing all vehicles. Methods will not be applied if the first argument is false.

--- a/docs/ox_core/Vehicle/Server/methods.md
+++ b/docs/ox_core/Vehicle/Server/methods.md
@@ -45,6 +45,10 @@ vehicle.getCoords()
 
 Despawns the vehicle but doesn't save it or update the stored value.
 
+```lua
+vehicle.despawn()
+```
+
 ## vehicle.delete
 
 Remove the vehicle from the database and despawns the entity.

--- a/docs/ox_lib/Interface/Client/context.md
+++ b/docs/ox_lib/Interface/Client/context.md
@@ -51,7 +51,7 @@ lib.registerContext(context)
     * onSelect: `function`
       * Function that's ran when the button is clicked.
     * icon?: `string`
-      * FontAwesome icon that will be displayed on the left side, works the same as notification and textui icons.
+      * FontAwesome icon that will be displayed on the left side, works the same as notification and textui icons. Remove any prefixes like `fas` or `fa` and just use the icon name.
     * iconColor?: `string`
       * Colour of the displayed icon.
     * progress?: `number`


### PR DESCRIPTION
Small changes include:
- adding yarn.lock to the .gitignore file.
- Being more 'specific' about vehicle.despawn.
- Specifying how to use the `icon` property for lib.registerContext.