### PR TITLE
add: health and armour to cache

### DIFF
--- a/pages/ox_lib/Modules/Cache/Client.mdx
+++ b/pages/ox_lib/Modules/Cache/Client.mdx
@@ -8,6 +8,10 @@ Values and cache functionality available to the client, in addition to the [shar
 
 - ped: `number`
   - player entity id
+- health: `number`
+  - current player health
+- armour: `number`
+  - current player armour
 - playerId: `number`
   - player id
 - serverId: `number`


### PR DESCRIPTION
Adds health and armour cache info to ox_lib docs, in https://github.com/overextended/ox_lib/pull/462 .