### PR TITLE
chore(oxlib/require): Add warning for client modules

### DIFF
--- a/pages/ox_lib/Modules/Require/Shared.mdx
+++ b/pages/ox_lib/Modules/Require/Shared.mdx
@@ -1,3 +1,5 @@
+import { Callout } from 'nextra/components';
+
 # Shared
 
 ## require
@@ -12,6 +14,22 @@ Loads the given module. The function starts by indexing the `loaded` table to de
 ```lua
 require 'modname'
 ```
+
+<Callout type="warning">
+
+Client modules must be defined in the `file` section of the resource manifest.
+
+```lua filename="fxmanifest.lua"
+file 'modname.lua'
+-- or
+files {
+  'modname.lua'
+}
+```
+
+</Callout>
+
+
 
 ### Usage Example
 


### PR DESCRIPTION
Just thought it would be a nice warning since I have seen some confusion regarding `require` not working in the client