### PR TITLE
Add missing landing page for Guides

### DIFF
--- a/pages/guides.mdx
+++ b/pages/guides.mdx
@@ -1,0 +1,9 @@
+# Guides
+
+General guides for working with Overextended resources.
+
+- [Git](./guides/git.mdx)
+- [NodeJS](./guides/nodejs.mdx)
+- [PNPM](./guides/pnpm.mdx)
+- [Ox Types](./guides/types.mdx)
+- [Visual Studio Code](./guides/vscode.mdx)


### PR DESCRIPTION
Several posts from people being unable to make the logical leap of following a link to `Guides` and just looking at the side bar for navigating to them.

Adding this simple landing page to hold their hands.