### PR TITLE
Add new split convars for random loot

### DIFF
--- a/pages/ox_inventory.mdx
+++ b/pages/ox_inventory.mdx
@@ -140,7 +140,16 @@ set inventory:loglevel 1
 set inventory:randomprices true
 
 # Loot will randomly generate inside unowned vehicles and dumpsters
+# This value will be ignored if using 'inventory:randomvehicleloot' and / or 'inventory:randomdumpsterloot'
 set inventory:randomloot true
+
+# Loot will randomly generate inside unowned vehicles
+# Note: This will override 'inventory:randomloot' for unowned vehicles only
+set inventory:randomvehicleloot true
+
+# Loot will randomly generate inside dumpsters
+# Note: This will override 'inventory:randomloot' for dumpsters only
+set inventory:randomdumpsterloot true
 
 # Minimum job grade to remove items from evidence lockers
 set inventory:evidencegrade 2


### PR DESCRIPTION
This is the matching docs change for [PR #1647](https://github.com/overextended/ox_inventory/pull/1647)