### PR TITLE
docs:(ox_lib/notify): remove callout for iconColor

### DIFF
--- a/pages/ox_lib/Modules/Interface/Client/notify.mdx
+++ b/pages/ox_lib/Modules/Interface/Client/notify.mdx
@@ -65,9 +65,6 @@ Custom notifications with a lot of styling options.
   - set: `string`
     - Soundset the soundname is a member of.
   - name: `string`
-<Callout>
-  Setting `iconColor` will get rid of the contrasted icon colour and it's circular background.
-</Callout
 
 ## Usage Example
 


### PR DESCRIPTION
Notification icon now has a circular background even though the iconColor has been set.