### PR TITLE
Update progress.mdx

### DIFF
--- a/pages/ox_lib/Modules/Interface/Client/progress.mdx
+++ b/pages/ox_lib/Modules/Interface/Client/progress.mdx
@@ -30,6 +30,7 @@ Displays a running progress bar.
 - label: `string`
 - useWhileDead?: `boolean`
 - allowRagdoll?: `boolean`
+- allowSwimming?: `boolean`
 - allowCuffed?: `boolean`
 - allowFalling?: `boolean`
 - canCancel?: `boolean`
@@ -157,6 +158,7 @@ Similar to `lib.progressBar` except it displays a circle and you can define a po
   - Default: `'middle'`
 - useWhileDead?: `boolean`
 - allowRagdoll?: `boolean`
+- allowSwimming?: `boolean`
 - allowCuffed?: `boolean`
 - allowFalling?: `boolean`
 - canCancel?: `boolean`


### PR DESCRIPTION
Option not shown which may affect many people. This is to fix and show the option for `allowSwimming?: boolean`