### PR TITLE
fix(ox_lib/marker): Make example standalone

### DIFF
--- a/pages/ox_lib/Modules/Marker/Client.mdx
+++ b/pages/ox_lib/Modules/Marker/Client.mdx
@@ -43,13 +43,17 @@ end)
 
 ### Interactive Example
 ```lua
+
+local center = vec3(430.452759, -1026.108032, 27.846140)
+local uiText = "Press [E] to get notified"
+
 local point = lib.points.new({
-  coords = SharedConfig.Warehouse.coords,
+  coords = center,
   distance = 20,
 })
 
 local marker = lib.marker.new({
-  coords = GetEntityCoords(SharedConfig.Warehouse.coords),
+  coords = center,
   type = 1,
 })
 
@@ -67,7 +71,8 @@ function point:nearby()
       })
     end
   else
-    if lib.isTextUIOpen() then
+  local isOpen, currentText = lib.isTextUIOpen()
+    if isOpen and currentText == uiText then
       lib.hideTextUI()
     end
   end


### PR DESCRIPTION
The current marker example gets the point coords from a non existent SharedConfig and calls `GetEntityCoords` on what I assume is a vector value.

### Changes made
Add a new `center` local variable that holds a vector3 value (police parking lot coords)
Add a new `uiText` local variable that holds the text to be displayed.

Make use of the second argument returned by isTextUIOpen (the text currently being displayed) to compare it to `uiText`.
This prevents closing the text ui if it has been overriden.