### PR TITLE
Clarify weaponWheel description

### DIFF
--- a/pages/ox_inventory/Functions/Client.mdx
+++ b/pages/ox_inventory/Functions/Client.mdx
@@ -239,7 +239,7 @@ exports.ox_inventory:giveItemToTarget(serverId, slotId, count)
   - The amount of the item to give, with `nil`, `0` or a value above the slot count giving the entire stack away.
 ## weaponWheel
 
-Enables the weapon wheel, but disables the use of inventory items.
+Enables the weapon wheel, but disables the use of inventory weapons.
 
 Mostly used for weaponised vehicles, though could be called for "minigames"
 


### PR DESCRIPTION
Right now the docs state that enabling the `weaponWheel` via export will disable the use of inventory items, as a user reading the docs I would assume that is all items but this is not the case. It only disables weapons from being used

Discussion: https://github.com/overextended/ox_inventory/issues/1709