### PR TITLE
add: rotOrder in progress bar and inventory guides.

### DIFF
--- a/pages/ox_inventory/Guides/creatingItems.mdx
+++ b/pages/ox_inventory/Guides/creatingItems.mdx
@@ -51,7 +51,8 @@ options for the item.
       - model: `string` or `hash`
       - pos: `table` (x, y, z)
       - rot: `table` (x, y, z)
-      - bone: `number`
+      - bone?: `number`
+      - rotOrder?: `number`
     - disable?: `table`
       - Actions to be disabled during the progress bar.
       - move?: `boolean`

--- a/pages/ox_lib/Modules/Interface/Client/progress.mdx
+++ b/pages/ox_lib/Modules/Interface/Client/progress.mdx
@@ -68,6 +68,9 @@ Displays a running progress bar.
     - x: `number`
     - y: `number`
     - z: `number`
+  - rotOrder?: `number`
+    - [The order in which yaw, pitch and roll is applied.](https://docs.fivem.net/natives/?_0xAFBD61CC738D9EB9)
+    - Default: `0`
 - disable?: `table` (`object`)
   - move?: `boolean`
   - car?: `boolean`
@@ -196,6 +199,9 @@ Similar to `lib.progressBar` except it displays a circle and you can define a po
     - x: `number`
     - y: `number`
     - z: `number`
+  - rotOrder?: `number`
+    - [The order in which yaw, pitch and roll is applied.](https://docs.fivem.net/natives/?_0xAFBD61CC738D9EB9)
+    - Default: `0`
 - disable?: `table` (`object`)
   - move?: `boolean`
   - car?: `boolean`


### PR DESCRIPTION
This adds rotOrder which is implemented in ox_lib but not documented yet, it is quite useful to document if you're using different rotation orders in your prop utility script or just in general, causing the prop to not show up like expected, for example, with [vx-prop-utils](https://hivedev.tebex.io/package/4795848).