### PR TITLE
fix: inventory:ignoreweapons incorrect example

### DIFF
--- a/pages/ox_inventory.mdx
+++ b/pages/ox_inventory.mdx
@@ -119,7 +119,7 @@ setr inventory:dropmodel "prop_med_bag_01b"
 # Disarm the player if an unexpected weapon is in use (i.e. did not use the weapon item)
 setr inventory:weaponmismatch true
 
-# Ignore weapon mismatch checks for the given weapon type (e.g. ['WEAPON_SHOVEL', 'WEAPON_HANDCUFFS'])
+# Ignore weapon mismatch checks for the given weapon type (e.g. {'WEAPON_SHOVEL', 'WEAPON_HANDCUFFS'})
 setr inventory:ignoreweapons []
 
 # Suppress weapon and ammo pickups


### PR DESCRIPTION
inventory:ignoreweapons under the hood uses json.decode which does not accept "arrays" with the (square brackets) but only array-like objects (curly brackets) 

example:
```lua
print(json.decode("['example', 'example2']"))
```
this will return an "Invalid value. (1)" error