### PR TITLE
Ox.GetGroup

### DIFF
--- a/pages/ox_core/Functions/server.mdx
+++ b/pages/ox_core/Functions/server.mdx
@@ -199,6 +199,22 @@ Ox.GetGroupsByType(groupType)
 
 - `string[]`
 
+## Ox.GetGroup
+
+Get an `OxGroup` from its name.
+
+```lua
+Ox.GetGroup(name)
+```
+
+**Parameters**
+
+- name: `string`
+
+**Returns**
+
+- `OxGroup`
+
 ## Ox.GetPlayer
 
 Get an `OxPlayer` from its enity id.


### PR DESCRIPTION
Adding the documentation for Ox.GetGroup.

Reference https://github.com/overextended/ox_core/blob/783496a50aef20e3b6643aaf45c476f90e524e5a/server/groups/index.ts#L12