### PR TITLE
docs: Tweak ox_inventory crafting guide to include undocumented label & icon variables + minor indentation change

### DIFF
--- a/pages/ox_inventory/Guides/crafting.mdx
+++ b/pages/ox_inventory/Guides/crafting.mdx
@@ -14,8 +14,8 @@ Crafting locations, items and their ingredients are defined in [data/crafting.lu
         {
             name = 'lockpick',
             ingredients = {
-            garbage = 3,
-            WEAPON_HAMMER = 0.1
+              garbage = 3,
+              WEAPON_HAMMER = 0.1
             },
             duration = 5000,
             count = 3,
@@ -24,20 +24,22 @@ Crafting locations, items and their ingredients are defined in [data/crafting.lu
         {
             name = 'garbage',
             ingredients = {
-            cola = 1
+              cola = 1
             },
             metadata = { description = 'An empty soda can.', weight = 20, image = 'trash_can' }
         },
     },
     points = {
-        vec3(-1147.083008, -2002.662109, 13.180260),
-        },
+      vec3(-1147.083008, -2002.662109, 13.180260),
+    },
     zones = {
         {
-            coords = vec3(-1146.2, -2002.05, 13.2),
-            size = vec3(3.8, 1.05, 0.15),
-            distance = 1.5,
-            rotation = 315.0,
+          label = 'Open Crafting Bench',
+          icon = 'fa-solid fa-wrench',
+          coords = vec3(-1146.2, -2002.05, 13.2),
+          size = vec3(3.8, 1.05, 0.15),
+          distance = 1.5,
+          rotation = 315.0,
         },
     },
     blip = { id = 566, colour = 31, scale = 0.8 },
@@ -66,6 +68,8 @@ Crafting locations, items and their ingredients are defined in [data/crafting.lu
   - `{["police"] = 0, ["ambulance"] = 2}`
 - zones: `table`
   - ox_lib targeting zones used for ox_target.
+  - label: `string`
+  - icon: `string`
   - coords: `vector3`
   - size: `vector3`
   - distance: `number`


### PR DESCRIPTION
Include undocumented variables & fix indentation when showing an example of a crafting bench.