### PR TITLE
fix(ox_core): Fix errors in ox_core docs

### DIFF
--- a/pages/ox_core.mdx
+++ b/pages/ox_core.mdx
@@ -68,7 +68,7 @@ You can import ox_core definitions by loading `@ox_core/lib/init.lua` into your 
 
     If you prefer, you can use our [require](../ox_lib/Modules/Require/Shared) function from [ox_lib](../ox_lib).
     ```lua
-    local Ox = require '@ox_core/lib/init'
+    local Ox = require '@ox_core.lib.init'
     ```
 
   </Tab>
@@ -96,7 +96,7 @@ These convars should use the `setr` command to be read by clients.
 
 - `ox:debug`
   - Default: `false`
-  - Enables debug messages and commands. Enabled by default when using `pnpm watch`.
+  - Enables debug messages and commands. Also allows players to have the same identifiers. Enabled by default when using `pnpm watch`.
 - `ox:characterSlots`
   - Default: `1`
   - Sets the number of character slots available for character selection resources (e.g. ox_charselect).

--- a/pages/ox_core/Classes/Client/OxPlayer.mdx
+++ b/pages/ox_core/Classes/Client/OxPlayer.mdx
@@ -116,7 +116,7 @@ player.getStatuses()
 
 ## OxPlayer.hasPermission
 
-Checks if a user has been granted a permission by one of their groups.
+Checks if a user has a permission, given by one of their groups.
 
 ```lua
 player.hasPermission(permission)

--- a/pages/ox_core/Classes/Server/OxAccount.mdx
+++ b/pages/ox_core/Classes/Server/OxAccount.mdx
@@ -2,6 +2,8 @@
 title: OxAccount
 ---
 
+import { Tabs, Tab } from 'nextra-theme-docs';
+
 ## OxAccount
 
 - accountId` number`
@@ -40,12 +42,12 @@ account.get(key)
 Add funds to the account.
 
 ```lua
-account.addBalance({ amount, message })
+account.addBalance(data)
 ```
 
 **Parameters**
 
-- `object`
+- data: `object`
   - amount: `number`
   - message?: `string`
 
@@ -55,13 +57,22 @@ account.addBalance({ amount, message })
   - success: `boolean`
   - message: `'amount_not_number'` | `'no_balance'` | `'something_went_wrong'`
 
+<Tabs items={['Lua']}>
+  <Tab>
+    ```lua
+    account.addBalance({ amount = 1000, message = 'Paycheck' })
+    ```
+
+  </Tab>
+</Tabs>
+
 
 ## OxAccount.removeBalance
 
 Remove funds from the account.
 
 ```lua
-account.removeBalance({ amount, message, overdraw })
+account.removeBalance(data)
 ```
 
 **Parameters**
@@ -70,6 +81,7 @@ account.removeBalance({ amount, message, overdraw })
   - amount: `number`
   - message?: `string`
   - overdraw?: `boolean`
+    - Removes balance even if not enough is present (Negative balance)
 
 **Returns**
 
@@ -77,13 +89,21 @@ account.removeBalance({ amount, message, overdraw })
   - success: `boolean`
   - message: `'amount_not_number'` | `'no_balance'` | `'something_went_wrong'`
 
+<Tabs items={['Lua']}>
+  <Tab>
+    ```lua
+    account.removeBalance({ amount = 1000, message = 'Impound', overdraw = true })
+    ```
+
+  </Tab>
+</Tabs>
 
 ## OxAccount.transferBalance
 
 Transfer funds to another account.
 
 ```lua
-account.transferBalance({ toId, amount, overdraw, message, note, actorId })
+account.transferBalance(data)
 ```
 
 **Parameters**
@@ -93,8 +113,10 @@ account.transferBalance({ toId, amount, overdraw, message, note, actorId })
     - The accountId to transfer funds to.
   - amount: `number`
   - message?: `string`
+    - Message for the receiver
   - overdraw?: `boolean`
   - note?: `string`
+    - Note for the initiator
   - actorId? `number`
     - The charId of the player initiating the transfer.
 
@@ -104,13 +126,28 @@ account.transferBalance({ toId, amount, overdraw, message, note, actorId })
   - success: `boolean`
   - message: `'amount_not_number'` | `'no_balance'` | `'something_went_wrong'`
 
+<Tabs items={['Lua']}>
+  <Tab>
+    ```lua
+    account.transferBalance({
+      toId = 100000000,
+      amount = 20,
+      message = 'Impound charge for plate ABC123',
+      overdraw = false,
+      note = 'Impound payment',
+    })
+    ```
+
+  </Tab>
+</Tabs>
+
 
 ## OxAccount.depositMoney
 
 Deposit money into the account.
 
 ```lua
-account.transferBalance(playerId, amount, message, note)
+account.depositMoney(playerId, amount, message, note)
 ```
 
 **Parameters**
@@ -133,7 +170,7 @@ account.transferBalance(playerId, amount, message, note)
 Withdraw money from the account.
 
 ```lua
-account.transferBalance(playerId, amount, message, note)
+account.withdrawMoney(playerId, amount, message, note)
 ```
 
 **Parameters**

--- a/pages/ox_core/Classes/Server/OxPlayer.mdx
+++ b/pages/ox_core/Classes/Server/OxPlayer.mdx
@@ -8,7 +8,6 @@ title: OxPlayer
 - identifier: `string`
 - ped: `number`
 - source: `number`
-- state: `StateBagInterface`
 - stateId: `string`
 - userId: `number`
 - username: `string`
@@ -104,7 +103,7 @@ player.emit(eventName, ...args)
 
 ## OxPlayer.get
 
-Get the value of specific key from the player's metadata.
+Get the value of a specific key from the player's metadata.
 
 ```lua
 player.get(key)
@@ -121,7 +120,7 @@ player.get(key)
 
 ## OxPlayer.getAccount
 
-Returns the player's default account.
+Returns the player's default OxAccount object.
 
 ```lua
 player.getAccount()
@@ -129,7 +128,7 @@ player.getAccount()
 
 **Returns**
 
-- `OxAccount`
+- [`OxAccount`](/ox_core/Classes/Server/OxAccount)
 
 
 ## OxPlayer.getCoords
@@ -177,8 +176,8 @@ player.getGroupByType(type)
 
 **Returns**
 
-- `string`
-- `number`
+- `string?`
+- `number?`
 
 
 ## OxPlayer.getGroups
@@ -231,19 +230,6 @@ player.getLicenses()
     - `[key: string]: any`
 
 
-## OxPlayer.getState
-
-Returns the player's statebag interface.
-
-```lua
-player.getState()
-```
-
-**Returns**
-
-- `StateBagInterface`
-
-
 ## OxPlayer.getStatus
 
 Returns the value of the status.
@@ -258,7 +244,7 @@ player.getStatus(statusName)
 
 **Returns**
 
-- `number`
+- value: `number`
 
 
 ## OxPlayer.getStatuses
@@ -423,14 +409,14 @@ player.setActiveCharacter(data)
 Sets a group the player is in as their active or "primary" group. If no arguments are passed, no active group will be set.
 
 ```lua
-player.setActiveGroup(groupName?: string, temp?: boolean)
+player.setActiveGroup(groupName?: string, temporary?: boolean)
 ```
 
 **Parameters**
 
 - groupName: `string`
 - temporary?: `boolean`
-  - If `true` it will persist through sessions.
+  - If `true` it will not persist through sessions.
 
 **Returns**
 

--- a/pages/ox_core/Classes/Server/OxVehicle.mdx
+++ b/pages/ox_core/Classes/Server/OxVehicle.mdx
@@ -58,8 +58,25 @@ vehicle.get(key)
 Returns the vehicle's current coordinates.
 
 ```lua
-vehicle.getCoords(): Vector3
+vehicle.getCoords()
 ```
+
+**Returns**
+
+- `vector3`
+
+## OxVehicle.getProperties
+
+Returns the vehicle's properties object.
+
+```lua
+vehicle.getProperties()
+```
+
+**Returns**
+
+- `VehicleProperties`
+
 
 
 ## OxVehicle.getState
@@ -115,7 +132,7 @@ vehicle.save()
 - `number`
 
 
-### OxVehicle.set
+## OxVehicle.set
 
 Stores a value in the vehicle's metadata, which will be saved to the database (_this behaviour is likely to be removed_).
 
@@ -182,7 +199,7 @@ vehicle.setProperties(properties, apply)
 
 ## OxVehicle.setStored
 
-Sets the vehicle as "stored" at the given value (e.g. impound, garage, null), and optionally despawns the vehicle.
+Sets the vehicle as "stored" at the given value (e.g. impound, garage, null), and optionally despawns and saves the vehicle.
 
 ```lua
 vehicle.setStored(value, despawn)

--- a/pages/ox_core/Events/client.mdx
+++ b/pages/ox_core/Events/client.mdx
@@ -16,11 +16,19 @@ function(playerId: number, isNew: boolean)
 
 ## ox:statusTick
 
-On each status tick
+On each status tick, returning changed statuses
 
 ```lua
 function(statuses: Record<string, OxStatus>)
 ```
+
+## ox:playerDeath
+
+When the character has died
+
+## ox:playerRevived
+
+When the character is revived
 
 ---
 

--- a/pages/ox_core/Functions/common.mdx
+++ b/pages/ox_core/Functions/common.mdx
@@ -1,9 +1,25 @@
+## Ox.GetGroupPermissions
+
+Returns the `OxGroupPermissions` object for the group
+
+```lua
+Ox.GetGroupPermissions(groupName)
+```
+
+**Parameters**
+
+- groupName: `string`
+
+**Returns**
+
+- `OxGroupPermissions`
+
 ## Ox.GetTopVehicleStats
 
 Returns an object containing the top vehicle stats, either overall or for a specific category (land, air, sea).
 
 ```lua
-Ox.GetTopVehicleStats(category)
+Ox.GetTopVehicleStats(category?)
 ```
 
 **Parameters**
@@ -28,7 +44,7 @@ Ox.GetTopVehicleStats(category)
 Returns VehicleData for all vehicles, or optionally a specific model or array of models.
 
 ```lua
-Ox.GetVehicleData(filter)
+Ox.GetVehicleData(filter?)
 ```
 
 **Parameters**

--- a/pages/ox_core/Functions/server.mdx
+++ b/pages/ox_core/Functions/server.mdx
@@ -56,7 +56,7 @@ Ox.CreateVehicle(data, coords, heading)
 
 **Returns**
 
-- `OxVehicle`
+- [`OxVehicle`](/ox_core/Classes/Server/OxVehicle)
 
 ## Ox.DeleteAccountInvoice
 
@@ -281,7 +281,7 @@ Ox.GetVehicle(entityId)
 
 **Returns**
 
-- `OxVehicle`
+- [`OxVehicle`](/ox_core/Classes/Server/OxVehicle)
 
 ## Ox.GetVehicleFromNetId
 
@@ -297,7 +297,7 @@ Ox.GetVehicleFromNetId(netId)
 
 **Returns**
 
-- `OxVehicle`
+- [`OxVehicle`](/ox_core/Classes/Server/OxVehicle)
 
 ## Ox.GetVehicleFromVin
 
@@ -313,7 +313,7 @@ Ox.GetVehicleFromVin(vin)
 
 **Returns**
 
-- `OxVehicle`
+- [`OxVehicle`](/ox_core/Classes/Server/OxVehicle)
 
 ## Ox.RemoveGroupPermission
 
@@ -376,4 +376,4 @@ Ox.SpawnVehicle(dbId, coords, heading)
 
 **Returns**
 
-- `OxVehicle`
+- [`OxVehicle`](/ox_core/Classes/Server/OxVehicle)


### PR DESCRIPTION
This should remove most of the big errors in the ox_core docs that I've seen causing issues in the discord. It also adds some examples to certain functions which aren't as straight forward or are on the more complex side.