### PR TITLE
fix(ox_core/events): wrong value type in status tick event parameter

### DIFF
--- a/pages/ox_core/Events/client.mdx
+++ b/pages/ox_core/Events/client.mdx
@@ -19,7 +19,7 @@ function(playerId: number, isNew: boolean)
 On each status tick
 
 ```lua
-function(statuses: Record<string, OxStatus>)
+function(statuses: Record<string, number>)
 ```
 
 ---


### PR DESCRIPTION
`ox:statusTick` event takes only one parameter, that being a status name (key) and the value of that status (number, not OxStatus).