### PR TITLE
add license(s) exports to core

### DIFF
--- a/pages/ox_core/Functions/server.mdx
+++ b/pages/ox_core/Functions/server.mdx
@@ -393,3 +393,31 @@ Ox.SpawnVehicle(dbId, coords, heading)
 **Returns**
 
 - [`OxVehicle`](/ox_core/Classes/Server/OxVehicle)
+
+## Ox.GetLicense
+
+Get license data from its name.
+
+```lua
+Ox.GetLicense(name)
+```
+
+**Parameters**
+
+- name: `string`
+
+**Returns**
+
+- `OxLicense`
+
+## Ox.GetLicenses
+
+Get all licenses' data.
+
+```lua
+Ox.GetLicenses()
+```
+
+**Returns**
+
+- `OxLicense[]`


### PR DESCRIPTION
As promised in https://github.com/overextended/ox_core/pull/222.