### PR TITLE
add doc for missing lib.requestAudioBank 

### DIFF
--- a/pages/ox_lib/Modules/Streaming/Client.mdx
+++ b/pages/ox_lib/Modules/Streaming/Client.mdx
@@ -58,6 +58,32 @@ Throws errors for invalid assets and returns true if the asset is loaded.
   - Number of ticks to wait for the asset to load.
   - Default: `10000`
 
+## lib.requestAudioBank
+
+<Callout>
+    Remember to call `ReleaseScriptAudioBank(set)` at the end of you code!
+</Callout>
+
+<Tabs items={["Lua", "JS"]}>
+  <Tab>
+    ```lua
+    lib.requestAudioBank(audioBank, timeout)
+    ```
+  </Tab>
+  <Tab>
+    ```ts
+    import lib from '@overextended/ox_lib/client'
+
+    lib.requestAudioBank(audioBank, timeout)
+    ```
+  </Tab>
+</Tabs>
+
+- audioBank: `string`
+- timeout?: `number`
+  - Number of ticks to wait for the asset to load.
+  - Default: `10000`
+
 ## lib.requestModel
 
 <Callout>

--- a/pages/ox_lib/Modules/Streaming/Client.mdx
+++ b/pages/ox_lib/Modules/Streaming/Client.mdx
@@ -64,25 +64,15 @@ Throws errors for invalid assets and returns true if the asset is loaded.
     Remember to call `ReleaseScriptAudioBank(set)` at the end of you code!
 </Callout>
 
-<Tabs items={["Lua", "JS"]}>
-  <Tab>
-    ```lua
-    lib.requestAudioBank(audioBank, timeout)
-    ```
-  </Tab>
-  <Tab>
-    ```ts
-    import lib from '@overextended/ox_lib/client'
-
-    lib.requestAudioBank(audioBank, timeout)
-    ```
-  </Tab>
-</Tabs>
+```lua
+lib.requestAudioBank(audioBank, timeout)
+```
+  
 
 - audioBank: `string`
 - timeout?: `number`
   - Number of ticks to wait for the asset to load.
-  - Default: `10000`
+  - Default: `30000`
 
 ## lib.requestModel
 


### PR DESCRIPTION
I noticed that the requestAudioBank  function seems to be missing from the docs. This PR adds the necessary for it 