### PR TITLE
Feat: inventory instance statebag

### DIFF
--- a/pages/ox_inventory/Functions/Client.mdx
+++ b/pages/ox_inventory/Functions/Client.mdx
@@ -509,6 +509,16 @@ else
 end
 ```
 
+### instance
+
+Is used to define if a player is in a specific instance (i.e. property, arena) where drops should be isolated.
+
+- instance: `string` | `number` | `nil`
+
+```lua
+LocalPlayer.state.instance = "property_1"
+```
+
 ### canUseWeapons
 
 Allows you to enable/disable the use of weapons for a player.


### PR DESCRIPTION
This PR adds documentation on the `instance` statebag value which is used to limit drops to specific instances (not necessarily just routing buckets) in shared areas (i.e. properties).